### PR TITLE
Add distinctUntilChanged on the state stream

### DIFF
--- a/androidreactor/src/main/kotlin/at/florianschuster/androidreactor/Reactor.kt
+++ b/androidreactor/src/main/kotlin/at/florianschuster/androidreactor/Reactor.kt
@@ -93,6 +93,7 @@ interface Reactor<Action, Mutation, State> where Action : Any, Mutation : Any, S
             .observeOn(AndroidSchedulers.mainThread())
 
         val transformedState = transformState(state)
+            .distinctUntilChanged()
             .doOnNext { currentState = it }
             .replay(1)
 

--- a/androidreactor/src/main/kotlin/at/florianschuster/androidreactor/Reactor.kt
+++ b/androidreactor/src/main/kotlin/at/florianschuster/androidreactor/Reactor.kt
@@ -87,13 +87,13 @@ interface Reactor<Action, Mutation, State> where Action : Any, Mutation : Any, S
 
         val state: Observable<State> = transformedMutation
             .scan(initialState) { state, mutate -> reduce(state, mutate) }
+            .distinctUntilChanged()
             .doOnError(AndroidReactor::log)
             .onErrorResumeNext { _: Throwable -> Observable.empty() }
             .startWith(initialState)
             .observeOn(AndroidSchedulers.mainThread())
 
         val transformedState = transformState(state)
-            .distinctUntilChanged()
             .doOnNext { currentState = it }
             .replay(1)
 


### PR DESCRIPTION
## Overview

There's no reason to notify a client of a new state if a Mutation doesn't change the state.